### PR TITLE
fix: aetheric API flush on company change

### DIFF
--- a/src/components/auth/login-local.vue
+++ b/src/components/auth/login-local.vue
@@ -47,7 +47,7 @@
     import { useProfileStore } from "~/store/profile";
 
     const router = useRouter();
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
     const authStore = useAuthStore();
 
     // Reactive vars

--- a/src/components/portal/assets/pilots/index.vue
+++ b/src/components/portal/assets/pilots/index.vue
@@ -2,5 +2,5 @@
 </template>
 
 <script setup lang="ts">
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 </script>

--- a/src/components/portal/assets/pods-and-pads/index.vue
+++ b/src/components/portal/assets/pods-and-pads/index.vue
@@ -2,5 +2,5 @@
 </template>
 
 <script setup lang="ts">
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 </script>

--- a/src/components/portal/config-bar.vue
+++ b/src/components/portal/config-bar.vue
@@ -2,10 +2,10 @@
     <section class="container">
         <div class="row mx-auto mt-2">
             <div class="col">
-                <SlidersHorizontal size="1.5rem" class="fill-orange" />
+                <IconSlidersHorizontal size="1.5rem" class="fill-orange" />
             </div>
             <div class="col d-flex justify-content-end">
-                <SquaresFour size="1.5rem" class="text-success" />
+                <IconSquaresFour size="1.5rem" class="text-success" />
             </div>
         </div>
     </section>

--- a/src/components/portal/nav/account.vue
+++ b/src/components/portal/nav/account.vue
@@ -68,7 +68,7 @@
     import type { ICompany, IUser } from "~/modules/aetheric-api";
 
     const { $bootstrap } = useNuxtApp();
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 
     const user = defineModel<IUser>("user", {
         default: {},

--- a/src/components/portal/nav/index.vue
+++ b/src/components/portal/nav/index.vue
@@ -89,7 +89,7 @@
     const profileStore = useProfileStore();
     const user = ref(await profileStore.getUser());
     const menuIcon = ref("IconList");
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 
     // Reactive vars
     const { data: currentCompany } = await useAsyncData(

--- a/src/components/portal/profile/payment/index.vue
+++ b/src/components/portal/profile/payment/index.vue
@@ -59,7 +59,7 @@
     import type { IPaymentMethod, IPaymentMethodCreate } from "~/modules/aetheric-api";
 
     const profileStore = useProfileStore();
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 
     // Reactive vars
     const user = ref(await profileStore.getUser());

--- a/src/components/portal/profile/privacy-and-security/index.vue
+++ b/src/components/portal/profile/privacy-and-security/index.vue
@@ -19,7 +19,7 @@
     import type { IPrivacySettings } from "~/modules/aetheric-api";
 
     const profileStore = useProfileStore();
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 
     // Reactive vars
     const user = ref(await profileStore.getUser());

--- a/src/components/portal/profile/settings/index.vue
+++ b/src/components/portal/profile/settings/index.vue
@@ -49,7 +49,7 @@
 
     const profileStore = useProfileStore();
     const user = ref(await profileStore.getUser());
-    const $api = useAethericApi(useCurrentCompany());
+    const $api = useAethericApi(useCurrentCompany().value);
 
     // Reactive vars
     const { data: addresses } = await useAsyncData<IAddress[]>(

--- a/src/composables/googleLogin.ts
+++ b/src/composables/googleLogin.ts
@@ -5,7 +5,7 @@ import { useProfileStore } from "@/store/profile";
 import type { IGoogleJwtResponse, IUser } from "~/modules/aetheric-api";
 
 const handleGoogleLogin = async (response: CredentialResponse) => {
-  const $api = useAethericApi(useCurrentCompany());
+  const $api = useAethericApi(useCurrentCompany().value);
   const { $decodeJwt } = useNuxtApp();
   const decoded = $decodeJwt(response.credential);
 

--- a/src/modules/aetheric-api/runtime/api/addresses.ts
+++ b/src/modules/aetheric-api/runtime/api/addresses.ts
@@ -1,6 +1,10 @@
 import ApiFactory from "../";
 import type { IGetForIdRequest, IAdvancedSearchFilter } from "../types";
-import type { IAddressesModule, IAddress, IAddressCreate } from "../types/addresses";
+import type {
+  IAddressesModule,
+  IAddress,
+  IAddressCreate,
+} from "../types/addresses";
 
 class AddressesModule extends ApiFactory<IAddress> implements IAddressesModule {
   resource = "/addresses";
@@ -13,7 +17,10 @@ class AddressesModule extends ApiFactory<IAddress> implements IAddressesModule {
   };
 
   // ----------------------- create new address --------------------- //
-  async create(request: IAddressCreate): Promise<string | undefined> {
+  async create(
+    this: AddressesModule,
+    request: IAddressCreate
+  ): Promise<string | undefined> {
     return await super.create(request);
   }
 

--- a/src/modules/aetheric-api/runtime/api/aircraft.ts
+++ b/src/modules/aetheric-api/runtime/api/aircraft.ts
@@ -10,9 +10,9 @@ import type {
 class AircraftModule extends ApiFactory<IAircraft> implements IAircraftModule {
   resource: string;
 
-  constructor(fetchOptions: any, currentCompany: Ref<string>) {
+  constructor(fetchOptions: any, currentCompany: string) {
     super(fetchOptions);
-    this.resource = `/assets/supplier/${currentCompany.value}/aircraft`;
+    this.resource = `/assets/supplier/${currentCompany}/aircraft`;
   }
 
   // ----------------------- get company data --------------------- //
@@ -23,7 +23,10 @@ class AircraftModule extends ApiFactory<IAircraft> implements IAircraftModule {
   };
 
   // ----------------------- create new company --------------------- //
-  async create(request: IAircraftCreate): Promise<string | undefined> {
+  async create(
+    this: AircraftModule,
+    request: IAircraftCreate
+  ): Promise<string | undefined> {
     return await super.create(request);
   }
 

--- a/src/modules/aetheric-api/runtime/api/companies.ts
+++ b/src/modules/aetheric-api/runtime/api/companies.ts
@@ -17,7 +17,10 @@ class CompaniesModule extends ApiFactory<ICompany> implements ICompaniesModule {
   };
 
   // ----------------------- create new company --------------------- //
-  async create(request: ICompanyCreate): Promise<string | undefined> {
+  async create(
+    this: CompaniesModule,
+    request: ICompanyCreate
+  ): Promise<string | undefined> {
     return await super.create(request);
   }
 

--- a/src/modules/aetheric-api/runtime/api/contacts.ts
+++ b/src/modules/aetheric-api/runtime/api/contacts.ts
@@ -17,7 +17,10 @@ class ContactsModule extends ApiFactory<IContact> implements IContactsModule {
   };
 
   // ----------------------- create new contact --------------------- //
-  async create(request: IContactCreate): Promise<string | undefined> {
+  async create(
+    this: ContactsModule,
+    request: IContactCreate
+  ): Promise<string | undefined> {
     return await super.create(request);
   }
 

--- a/src/modules/aetheric-api/runtime/api/modules.ts
+++ b/src/modules/aetheric-api/runtime/api/modules.ts
@@ -7,7 +7,7 @@ import AircraftModule from "./aircraft";
 import type { FetchOptions, Modules } from "../types";
 
 /** an object containing all repositories we need to expose */
-const modules = (fetchOptions: FetchOptions, currentCompany: Ref<string>): Modules => {
+const modules = (fetchOptions: FetchOptions, currentCompany: string): Modules => {
   return {
     auth: new AuthModule(fetchOptions),
     users: new UsersModule(fetchOptions),

--- a/src/modules/aetheric-api/runtime/composables/useAethericApi.ts
+++ b/src/modules/aetheric-api/runtime/composables/useAethericApi.ts
@@ -12,7 +12,7 @@ const modules: Ref<Modules | undefined> = ref(undefined);
 type EnumAddressType = typeof EnumAddress;
 type EnumContactType = typeof EnumContact;
 
-export const useAethericApi = (currentCompany: Ref<string>) => {
+export const useAethericApi = (currentCompany: string) => {
   const nuxtApp = useNuxtApp();
   if(modules.value === undefined) {
     const options: ModuleOptions = nuxtApp.$config.public.api as ModuleOptions;
@@ -28,6 +28,10 @@ export const useAethericApi = (currentCompany: Ref<string>) => {
   }
 
   return modules.value;
+}
+
+export const flushAethericApi = () => {
+  modules.value = undefined;
 }
 
 export { EnumContact, EnumAddress, type EnumAddressType, type EnumContactType };

--- a/src/modules/aetheric-api/runtime/composables/useMock.ts
+++ b/src/modules/aetheric-api/runtime/composables/useMock.ts
@@ -73,42 +73,49 @@ const storeAircraft: RemovableRef<{ [key: string]: IAircraft }> =
     } as IAircraft,
     "6": {
       uuid: "6",
+      owner: "1",
       name: "Small Wing",
       imgSrc: "/img/demo/drone-b.png",
       status: EnumVehicleState.NEEDS_MAINTENANCE
     } as IAircraft,
     "7": {
       uuid: "7",
+      owner: "1",
       name: "Swift Falcon",
       imgSrc: "/img/demo/drone-b.png",
       status: EnumVehicleState.CHARGING
     } as IAircraft,
     "8": {
       uuid: "8",
+      owner: "1",
       name: "Sky Rider",
       imgSrc: "/img/demo/drone-a.png",
       status: EnumVehicleState.TAKE_OFF
     } as IAircraft,
     "9": {
       uuid: "9",
+      owner: "1",
       name: "Sky Rider",
       imgSrc: "/img/demo/drone-a.png",
       status: EnumVehicleState.IN_FLIGHT
     } as IAircraft,
     "10": {
       uuid: "10",
+      owner: "1",
       name: "Sky Rider",
       imgSrc: "/img/demo/drone-c.png",
       status: EnumVehicleState.PARKED
     } as IAircraft,
     "11": {
       uuid: "11",
+      owner: "1",
       name: "Sky Rider",
       imgSrc: "/img/demo/drone-a.png",
       status: EnumVehicleState.ARCHIVED
     } as IAircraft,
     "12": {
       uuid: "12",
+      owner: "1",
       name: "Sky Rider",
       imgSrc: "/img/demo/drone-c.png",
       status: EnumVehicleState.ARCHIVED
@@ -270,7 +277,7 @@ const storeCompanyProfiles: RemovableRef<{
 }> = useLocalStorage("mock/store/company_profiles", {
   "1": {
     company: "1",
-    aircraft: ["1", "2", "3", "4", "5"],
+    aircraft: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
     addresses: ["1", "2"],
     contactInfo: ["1", "2", "3"],
   },

--- a/src/modules/aetheric-api/runtime/index.ts
+++ b/src/modules/aetheric-api/runtime/index.ts
@@ -8,13 +8,14 @@ import type {
 } from "./types";
 
 abstract class ApiFactory<T> implements IApiFactory<T> {
-  abstract resource: string;
+  resource: string;
 
   private fetchOptions;
   private _error: string | undefined;
 
   constructor(fetchOptions: any) {
     this.fetchOptions = fetchOptions;
+    this.resource = "";
   }
 
   /**

--- a/src/modules/aetheric-api/runtime/mock/modules.ts
+++ b/src/modules/aetheric-api/runtime/mock/modules.ts
@@ -7,7 +7,7 @@ import AircraftModule from "./aircraft";
 import type { FetchOptions, Modules } from "../types";
 
 /** an object containing all repositories we need to expose */
-const modules = (fetchOptions: FetchOptions, currentCompany: Ref<string>): Modules => {
+const modules = (fetchOptions: FetchOptions, currentCompany: string): Modules => {
   return {
     auth: new AuthModule(fetchOptions),
     users: new UsersModule(fetchOptions),

--- a/src/modules/aetheric-api/runtime/mock/users.ts
+++ b/src/modules/aetheric-api/runtime/mock/users.ts
@@ -142,7 +142,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
   // ----------------------- create new user --------------------- //
   create = async (request: IUserCreate): Promise<string | undefined> => {
     const uuid: string = crypto.randomUUID();
-    const $api = mockModules({ baseURL: "" }, ref(""));
+    const $api = mockModules({ baseURL: "" }, "");
 
     const user = request as IUser;
     user.uuid = uuid;
@@ -174,7 +174,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
   };
 
   addCompany = async (request: IUserCompany): Promise<boolean> => {
-    const $api = mockModules({ baseURL: "" }, ref(""));
+    const $api = mockModules({ baseURL: "" }, "");
     const uuid = await $api.companies.create(request.company);
 
     if (uuid) {
@@ -189,7 +189,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
     if (
       useUserProfiles().value[request.uuid].companies.includes(company.uuid)
     ) {
-      const $api = mockModules({ baseURL: "" }, ref(""));
+      const $api = mockModules({ baseURL: "" }, "");
       return await $api.companies.update(request.company as ICompany);
     }
 
@@ -213,7 +213,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
   };
 
   addContact = async (request: IUserContact): Promise<boolean> => {
-    const $api = mockModules({ baseURL: "" }, ref(""));
+    const $api = mockModules({ baseURL: "" }, "");
     const uuid = await $api.contacts.create(request.contact);
 
     if (uuid) {
@@ -228,7 +228,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
     if (
       useUserProfiles().value[request.uuid].contactInfo.includes(contact.uuid)
     ) {
-      const $api = mockModules({ baseURL: "" }, ref(""));
+      const $api = mockModules({ baseURL: "" }, "");
       return await $api.contacts.update(request.contact as IContact);
     }
 
@@ -252,7 +252,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
   };
 
   addAddress = async (request: IUserAddress): Promise<boolean> => {
-    const $api = mockModules({ baseURL: "" }, ref(""));
+    const $api = mockModules({ baseURL: "" }, "");
     const uuid = await $api.addresses.create(request.address);
 
     if (uuid) {
@@ -267,7 +267,7 @@ class UsersModule extends ApiFactory<IUser> implements IUsersModule {
     if (
       useUserProfiles().value[request.uuid].addresses.includes(address.uuid)
     ) {
-      const $api = mockModules({ baseURL: "" }, ref(""));
+      const $api = mockModules({ baseURL: "" }, "");
       return await $api.addresses.update(request.address as IAddress);
     }
 

--- a/src/modules/aetheric-api/runtime/types/aircraft.ts
+++ b/src/modules/aetheric-api/runtime/types/aircraft.ts
@@ -6,12 +6,21 @@ import type {
 import type { EnumVehicleState } from "./enums";
 
 export interface IAircraftModule extends IApiFactory<IAircraft> {
-  get: (request: IGetForIdRequest) => Promise<[IAircraft | undefined, boolean]>;
+  get: (
+    this: IAircraftModule,
+    request: IGetForIdRequest
+  ) => Promise<[IAircraft | undefined, boolean]>;
 
-  create(request: IAircraftCreate): Promise<string | undefined>;
-  update(request: IAircraft): Promise<boolean>;
+  create(
+    this: IAircraftModule,
+    request: IAircraftCreate
+  ): Promise<string | undefined>;
+  update(this: IAircraftModule, request: IAircraft): Promise<boolean>;
 
-  filter(request: IAdvancedSearchFilter): Promise<[IAircraft[], boolean]>;
+  filter(
+    this: IAircraftModule,
+    request: IAdvancedSearchFilter
+  ): Promise<[IAircraft[], boolean]>;
 }
 
 export interface IAircraftUpdateRequest {

--- a/src/modules/aetheric-api/runtime/types/index.ts
+++ b/src/modules/aetheric-api/runtime/types/index.ts
@@ -6,6 +6,8 @@ import type { IAddressesModule } from "./addresses";
 import type { IAircraftModule } from "./aircraft";
 
 export interface IApiFactory<T> {
+  resource: string;
+
   get error(): string | undefined;
   set error(error: string | undefined);
 


### PR DESCRIPTION
The assets/vtol page now uses `useAethericApi` to retrieve the asset data. This will automatically use the mock data if the API module is set to do so.
In addition, a bug has been fixed where using the `useAethericApi` didn't correctly get the asset data since the provided `currentCompany` variable wasn't accessible.